### PR TITLE
Performance improvements

### DIFF
--- a/bindings/python/compressed_storage_bindings.cpp
+++ b/bindings/python/compressed_storage_bindings.cpp
@@ -35,7 +35,8 @@ void init_compressed_storage(py::module_& m)
 
                 // Return a new instance of CompressedDataStorage
                 return std::make_shared<CompressedDataStorage<double>>(
-                    num_rows, num_cols, indptr_vec, indices_vec, data_vec, csc);
+                    num_rows, num_cols, std::move(indptr_vec), std::move(indices_vec),
+                    std::move(data_vec), csc);
             }))
         .def("num_rows", &CompressedDataStorage<double>::num_rows)
         .def("num_cols", &CompressedDataStorage<double>::num_cols)
@@ -60,8 +61,9 @@ void init_compressed_storage(py::module_& m)
                 std::vector<int> data_vec(data.data(), data.data() + data.size());
 
                 // Return a new instance of CompressedDataStorage
-                return std::make_shared<CompressedDataStorage<int>>(num_rows, num_cols, indptr_vec,
-                                                                    indices_vec, data_vec, csc);
+                return std::make_shared<CompressedDataStorage<int>>(
+                    num_rows, num_cols, std::move(indptr_vec), std::move(indices_vec),
+                    std::move(data_vec), csc);
             }))
         .def("num_rows", &CompressedDataStorage<int>::num_rows)
         .def("num_cols", &CompressedDataStorage<int>::num_cols)

--- a/bindings/python/grid_bindings.cpp
+++ b/bindings/python/grid_bindings.cpp
@@ -21,9 +21,19 @@ void init_grid(py::module_ &m)
         .def("num_nodes", &Grid::num_nodes)
         .def("num_faces", &Grid::num_faces)
         .def("num_cells", &Grid::num_cells)
-        .def("faces_of_node", &Grid::faces_of_node)
+        .def("faces_of_node", [](const Grid& g, int node) {
+            // faces_of_node return std::span (a non-owning memory view), which is not
+            // supported by pybind11. Therefore, we copy the data into a new vector.
+            // There is a way to avoid a copy here, but it requires more involvement.
+            auto s = g.faces_of_node(node);
+            return std::vector<int>(s.begin(), s.end());
+        })
         .def("nodes_of_face", &Grid::nodes_of_face)
-        .def("cells_of_face", &Grid::cells_of_face)
+        .def("cells_of_face", [](const Grid& g, int node) {
+            // See the comment above at faces_of_node.
+            auto s = g.cells_of_face(node);
+            return std::vector<int>(s.begin(), s.end());
+        })
         .def("faces_of_cell", &Grid::faces_of_cell)
         .def("sign_of_face_cell", &Grid::sign_of_face_cell)
         .def("nodes", &Grid::nodes)

--- a/include/compressed_storage.h
+++ b/include/compressed_storage.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <span>
 
 template <typename T>
 class CompressedDataStorage
@@ -23,13 +24,18 @@ class CompressedDataStorage
     const int num_cols();
 
     const std::vector<int>& row_ptr();
-    const std::vector<int>& col_idx();
+    const std::vector<int>& col_idx() const;
     const std::vector<T>& data();
 
-    // Getters for the compressed data storage. These return *copies* of the data. TODO!
-    std::vector<int> cols_in_row(int row);
-    std::vector<int> rows_in_col(int col);  // Change from int* to std::vector<int>
-
+    // Getters for the compressed data storage.
+    
+    // Getter for columns in a row, returns an immutable view of the data.
+    std::span<const int> cols_in_row(int row);
+    // Getter of rows in a column, creates a new vector, since the underlying data is
+    // not contiguious.
+    std::vector<int> rows_in_col(int col);
+    // Getter for values, returns a copy of the values. Use `data` to access the
+    // underlying data.
     std::vector<T> values();
     T value(const int row, const int col);
 
@@ -42,6 +48,8 @@ class CompressedDataStorage
     std::vector<int> m_col_ptr;   // For CSC format
     std::vector<int> m_row_idx;   // For CSC format
     std::vector<T> m_values_csc;  // For CSC format
+    // This class stores a sparse matrix in the CSR format. Optionally, the CSC indices
+    // can be constructed alongside. 
     bool m_csc_constructed = false;
 };
 

--- a/include/compressed_storage.h
+++ b/include/compressed_storage.h
@@ -13,8 +13,8 @@ class CompressedDataStorage
 {
    public:
     // Constructor for a matrix with indices and values given.
-    CompressedDataStorage(const int num_rows, const int num_cols, const std::vector<int>& row_ptr,
-                          const std::vector<int>& col_idx, const std::vector<T>& values,
+    CompressedDataStorage(const int num_rows, const int num_cols, std::vector<int> row_ptr,
+                          std::vector<int> col_idx, std::vector<T> values,
                           const bool construct_csc = false);
 
     // Destructor

--- a/include/compressed_storage.h
+++ b/include/compressed_storage.h
@@ -23,9 +23,9 @@ class CompressedDataStorage
     const int num_rows();
     const int num_cols();
 
-    const std::vector<int>& row_ptr();
+    const std::vector<int>& row_ptr() const;
     const std::vector<int>& col_idx() const;
-    const std::vector<T>& data();
+    const std::vector<T>& data() const;
 
     // Getters for the compressed data storage.
     

--- a/include/discr.h
+++ b/include/discr.h
@@ -1,7 +1,7 @@
 #ifndef FV_DISCR_H
 #define FV_DISCR_H
 
-#include <map>     // std::map
+#include <unordered_map>     // std::unordered_map
 #include <memory>  // std::unique_ptr
 
 #include "../include/compressed_storage.h"
@@ -26,9 +26,9 @@ struct ScalarDiscretization
 };
 
 ScalarDiscretization tpfa(const Grid& grid, const SecondOrderTensor& tensor,
-                          const std::map<int, BoundaryCondition>& bc_map);
+                          const std::unordered_map<int, BoundaryCondition>& bc_map);
 
 ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
-                          const std::map<int, BoundaryCondition>& bc_map);
+                          const std::unordered_map<int, BoundaryCondition>& bc_map);
 
 #endif  // FV_DISCR_H

--- a/include/grid.h
+++ b/include/grid.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include <span>
 
 #include "../include/compressed_storage.h"
 
@@ -33,9 +34,9 @@ class Grid
     // int num_boundary_faces();
 
     // Direct access to the compressed data storage
-    const std::vector<int> faces_of_node(const int node) const;
+    const std::span<const int> faces_of_node(const int node) const;
     const std::vector<int> nodes_of_face(const int face) const;
-    const std::vector<int> cells_of_face(const int face) const;
+    const std::span<const int> cells_of_face(const int face) const;
     const std::vector<int> faces_of_cell(const int cell) const;
     const int sign_of_face_cell(const int face, const int cell) const;
     const int num_nodes_of_face(const int face) const;

--- a/include/tensor.h
+++ b/include/tensor.h
@@ -2,6 +2,7 @@
 #define TENSOR_H
 
 #include <memory>
+#include <span>
 #include <vector>
 
 class SecondOrderTensor
@@ -25,13 +26,21 @@ class SecondOrderTensor
     const int dim() const;
 
     // Return the isotropic value for a given cell
-    double isotropic_data(int cell) const;
+    inline double isotropic_data(int cell) const noexcept
+    {
+        return m_k_full[cell * DATA_PER_CELL];
+    }
     // Return the diagonal values for a given cell (size = dim)
-    std::vector<double> diagonal_data(
-        int cell) const;  // returns size 3: [xx, yy, zz], zero-padded for 2D
+    inline std::span<const double, 3> diagonal_data(int cell) const noexcept
+    {
+        return std::span<const double, 3>(&m_k_full[cell * DATA_PER_CELL], 3);
+    }
+
     // Return the full tensor values for a given cell (size = dim*dim)
-    std::vector<double> full_data(
-        int cell) const;  // returns size 6: [xx, yy, zz, xy, xz, yz], zero-padded for 2D
+    inline std::span<const double, 6> full_data(int cell) const noexcept
+    {
+        return std::span<const double, 6>(&m_k_full[cell * DATA_PER_CELL], DATA_PER_CELL);
+    }
 
    private:
     int m_dim;
@@ -40,13 +49,15 @@ class SecondOrderTensor
     bool m_is_isotropic;
     bool m_is_diagonal;
 
-    std::vector<double> m_k_xx;
-    std::vector<double> m_k_yy;
-    std::vector<double> m_k_xy;
-    std::vector<double> m_k_zz;
-    std::vector<double> m_k_xz;
-    std::vector<double> m_k_yz;
-    std::vector<double> m_zeros;
+    std::vector<double> m_k_full;
+
+    static constexpr size_t K_XX_OFFSET = 0;
+    static constexpr size_t K_YY_OFFSET = 1;
+    static constexpr size_t K_ZZ_OFFSET = 2;
+    static constexpr size_t K_XY_OFFSET = 3;
+    static constexpr size_t K_XZ_OFFSET = 4;
+    static constexpr size_t K_YZ_OFFSET = 5;
+    static constexpr size_t DATA_PER_CELL = 6;
 };
 
 #endif  // TENSOR_H

--- a/src/compressed_storage.cpp
+++ b/src/compressed_storage.cpp
@@ -9,17 +9,25 @@ template class CompressedDataStorage<double>;
 // Constructor for a matrix with indices and values given.
 template <typename T>
 CompressedDataStorage<T>::CompressedDataStorage(const int num_rows, const int num_cols,
-                                                const std::vector<int>& row_ptr,
-                                                const std::vector<int>& col_idx,
-                                                const std::vector<T>& values,
-                                                const bool construct_csc)
+                                                std::vector<int> row_ptr, std::vector<int> col_idx,
+                                                std::vector<T> values, const bool construct_csc)
     : m_num_rows(num_rows),
       m_num_cols(num_cols),
-      m_row_ptr(row_ptr),
-      m_col_idx(col_idx),
-      m_values(values),
+      m_row_ptr(std::move(row_ptr)),
+      m_col_idx(std::move(col_idx)),
+      m_values(std::move(values)),
       m_csc_constructed(construct_csc)
 {
+    /*
+    Implementation note about passing by value and move semantics. An intuitive way to pass
+    const vector<T>& does not avoid copying memory - it happens when m_values(value) constructor
+    is called. It seems that the right way is to pass by value. If the lvalue is passed, e.g.
+    CompressedDataStorage(..., values, ...), it makes a copy once, and then moves values to
+    m_values. If the rvalue is passed, e.g. CompressedDataStorage(..., move(values), ...),
+    it does a move twice and avoids copying data. YZ does not understand why the same does not
+    work with passing by reference, but passing by value does the job.
+    */
+
     // Check if the sizes of the vectors are consistent with the number of rows and columns.
     if (m_row_ptr.size() != m_num_rows + 1)
     {

--- a/src/compressed_storage.cpp
+++ b/src/compressed_storage.cpp
@@ -142,7 +142,7 @@ std::vector<int> CompressedDataStorage<T>::rows_in_col(int col)
 }
 
 template <typename T>
-const std::vector<int>& CompressedDataStorage<T>::row_ptr()
+const std::vector<int>& CompressedDataStorage<T>::row_ptr() const
 {
     return m_row_ptr;
 }
@@ -154,7 +154,7 @@ const std::vector<int>& CompressedDataStorage<T>::col_idx() const
 }
 
 template <typename T>
-const std::vector<T>& CompressedDataStorage<T>::data()
+const std::vector<T>& CompressedDataStorage<T>::data() const
 {
     return m_values;
 }

--- a/src/compressed_storage.cpp
+++ b/src/compressed_storage.cpp
@@ -94,15 +94,11 @@ const int CompressedDataStorage<T>::num_cols()
 }
 
 template <typename T>
-std::vector<int> CompressedDataStorage<T>::cols_in_row(int row)
+std::span<const int> CompressedDataStorage<T>::cols_in_row(int row)
 {
-    const int size = m_row_ptr[row + 1] - m_row_ptr[row];
-    std::vector<int> cols(size);
-    for (int i = 0; i < size; i++)
-    {
-        cols[i] = m_col_idx[m_row_ptr[row] + i];
-    }
-    return cols;
+    const int start = m_row_ptr[row];
+    const int size = m_row_ptr[row + 1] - start;
+    return std::span<const int>(&m_col_idx[start], size);
 }
 
 template <typename T>
@@ -144,7 +140,7 @@ const std::vector<int>& CompressedDataStorage<T>::row_ptr()
 }
 
 template <typename T>
-const std::vector<int>& CompressedDataStorage<T>::col_idx()
+const std::vector<int>& CompressedDataStorage<T>::col_idx() const
 {
     return m_col_idx;
 }

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -589,7 +589,7 @@ std::unique_ptr<Grid> Grid::create_cartesian_grid(const int dim, const std::vect
     std::vector<int> data_face_nodes(face_nodes_vector.size(), 1);
 
     auto face_nodes = std::make_shared<CompressedDataStorage<int>>(
-        num_nodes, tot_num_faces, row_ptr_face_nodes, col_ptr_face_nodes, data_face_nodes, true);
+        num_nodes, tot_num_faces, std::move(row_ptr_face_nodes), std::move(col_ptr_face_nodes), std::move(data_face_nodes), true);
 
     // Create cell faces
     int tot_num_cells = num_cells[0] * num_cells[1];
@@ -753,7 +753,7 @@ std::unique_ptr<Grid> Grid::create_cartesian_grid(const int dim, const std::vect
     row_ptr[tot_num_faces] = col_idx_vector.size();
 
     auto face_cells = std::make_shared<CompressedDataStorage<int>>(
-        tot_num_faces, tot_num_cells, row_ptr, col_idx_vector, face_cell_sign_vector, true);
+        tot_num_faces, tot_num_cells, std::move(row_ptr), std::move(col_idx_vector), std::move(face_cell_sign_vector), true);
 
     Grid* g = new Grid(dim, std::move(nodes), face_cells, face_nodes);
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -65,7 +65,7 @@ const CompressedDataStorage<int>& Grid::cell_faces() const
     return *m_cell_faces;
 }
 
-const std::vector<int> Grid::faces_of_node(const int node) const
+const std::span<const int> Grid::faces_of_node(const int node) const
 {
     return m_face_nodes->cols_in_row(node);
 }
@@ -75,7 +75,7 @@ const std::vector<int> Grid::nodes_of_face(const int face) const
     return m_face_nodes->rows_in_col(face);
 }
 
-const std::vector<int> Grid::cells_of_face(const int face) const
+const std::span<const int> Grid::cells_of_face(const int face) const
 {
     return m_cell_faces->cols_in_row(face);
 }
@@ -326,7 +326,7 @@ void Grid::compute_geometry()
     // vector.
     for (int i{0}; i < m_num_faces; ++i)
     {
-        const std::vector<int> loc_cells = cells_of_face(i);
+        const auto loc_cells = cells_of_face(i);
 
         // Create a vector from the face center to the cell center
         double dot_prod = 0.0;

--- a/src/mpfa.cpp
+++ b/src/mpfa.cpp
@@ -672,15 +672,15 @@ ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
         const int num_cells = interaction_region.cells().size();
 
         // Initialize matrices for the discretization.
-        auto balance_cells = MatrixXd::Zero(num_faces, num_cells);
-        auto balance_faces = MatrixXd::Zero(num_faces, num_faces);
+        MatrixXd balance_cells = MatrixXd::Zero(num_faces, num_cells);
+        MatrixXd balance_faces = MatrixXd::Zero(num_faces, num_faces);
 
-        auto flux_cells = MatrixXd::Zero(num_faces, num_cells);
-        auto flux_faces = MatrixXd::Zero(num_faces, num_faces);
+        MatrixXd flux_cells = MatrixXd::Zero(num_faces, num_cells);
+        MatrixXd flux_faces = MatrixXd::Zero(num_faces, num_faces);
 
         // Initialize the matrices used for the nK (vector source) terms.
-        auto nK_matrix = MatrixXd::Zero(num_faces, SPATIAL_DIM * num_cells);
-        auto nK_one_sided = MatrixXd::Zero(num_faces, SPATIAL_DIM * num_cells);
+        MatrixXd nK_matrix = MatrixXd::Zero(num_faces, SPATIAL_DIM * num_cells);
+        MatrixXd nK_one_sided = MatrixXd::Zero(num_faces, SPATIAL_DIM * num_cells);
 
         // TODO: Should we use vectors for the inner quantities?
         loc_cell_centers.resize(num_cells);
@@ -953,7 +953,7 @@ ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
             // all other faces.
             // TODO: EK believes this also applies to Neumann faces. That should become
             // clear when applying this to a grid that is not K-orthogonal.
-            auto diag_matrix = Eigen::MatrixXd::Identity(num_faces, num_faces);
+            Eigen::MatrixXd diag_matrix = Eigen::MatrixXd::Identity(num_faces, num_faces);
             for (const auto& face : loc_dirichlet_faces)
             {
                 diag_matrix(face, face) = 0.0;  // Dirichlet faces

--- a/src/mpfa.cpp
+++ b/src/mpfa.cpp
@@ -1028,6 +1028,7 @@ ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
 
             // Vector of the global indices of the interaction region faces.
             std::vector<int> glob_indices_iareg_faces;
+            glob_indices_iareg_faces.reserve(interaction_region.faces().size());
             for (const auto& face_pair : interaction_region.faces())
             {
                 glob_indices_iareg_faces.push_back(face_pair.first);
@@ -1074,7 +1075,7 @@ ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
                 // center, using the set of basis functions for this cell.
                 const std::vector<double> pressure_diff =
                     p_diff(loc_face_centers[loc_face_pair.first], loc_cell_centers[loc_cell_ind],
-                           basis_map[glob_cell_ind]);
+                           basis_map.at(glob_cell_ind));
 
                 // Cell contribution to pressure reconstruction.
                 std::vector<double> cell_contribution(interaction_region.cells().size(), 0.0);
@@ -1186,7 +1187,8 @@ ScalarDiscretization mpfa(const Grid& grid, const SecondOrderTensor& tensor,
                 pressure_reconstruction_cell_col_idx.push_back(interaction_region.cells());
                 pressure_reconstruction_face_values.push_back(std::move(face_contribution));
                 pressure_reconstruction_face_row_idx.push_back(loc_face_pair.second);
-                pressure_reconstruction_face_col_idx.push_back(std::move(glob_indices_iareg_faces));
+                // The vector below is copied, it is constructed outside the loop once.
+                pressure_reconstruction_face_col_idx.push_back(glob_indices_iareg_faces);
 
                 vector_source_bound_pressure_values.push_back(
                     std::move(vector_source_cell_contribution));

--- a/src/mpfa.cpp
+++ b/src/mpfa.cpp
@@ -6,8 +6,6 @@
 #include <tuple>
 #include <unordered_set>
 #include <vector>
-#include <chrono>
-#include <iostream>
 
 #include "../include/discr.h"
 #include "../include/multipoint_common.h"
@@ -346,9 +344,6 @@ create_flux_vector_source_matrix(const std::vector<int>& row_indices,
                                  const int num_rows, const int num_cols,
                                  const int tot_num_transmissibilities)
 {
-    std::chrono::duration<double> duration;
-    auto tick = std::chrono::high_resolution_clock::now();
-
     constexpr int SPATIAL_DIM = 3;
     // Get the sorted indices for the row indices. This is common for the flux and
     // vector source data.
@@ -356,11 +351,6 @@ create_flux_vector_source_matrix(const std::vector<int>& row_indices,
     std::iota(sorted_row_indices.begin(), sorted_row_indices.end(), 0);
     std::sort(sorted_row_indices.begin(), sorted_row_indices.end(),
               [&row_indices](int i1, int i2) { return row_indices[i1] < row_indices[i2]; });
-
-    duration = std::chrono::high_resolution_clock::now() - tick;
-    std::cout << "first sort: " << duration.count() << " seconds."
-                << std::endl;
-    tick = std::chrono::high_resolution_clock::now();
 
     std::vector<int> row_ptr_flux, row_ptr_vector_source;
     row_ptr_flux.reserve(num_rows + 1);
@@ -392,11 +382,6 @@ create_flux_vector_source_matrix(const std::vector<int>& row_indices,
     std::vector<int> this_row_col_indices_flux, this_row_col_indices_vector_source;
     std::vector<double> this_row_data_flux, this_row_data_vector_source;
     std::vector<int> loc_sorted_indices, sorting_col_indices;
-
-    duration = std::chrono::high_resolution_clock::now() - tick;
-    std::cout << "before outer loop: " << duration.count() << " seconds."
-                << std::endl;
-    tick = std::chrono::high_resolution_clock::now();
 
     int current_ind = 0;
     for (int row_ind = 0; row_ind < num_row_occurrences.size(); ++row_ind)
@@ -543,11 +528,6 @@ create_flux_vector_source_matrix(const std::vector<int>& row_indices,
         sorting_col_indices.clear();
     }
 
-    duration = std::chrono::high_resolution_clock::now() - tick;
-    std::cout << "after outer loop: " << duration.count() << " seconds."
-                << std::endl;
-    tick = std::chrono::high_resolution_clock::now();
-
     // Create the compressed data storage for the flux.
     // EK note to self: The cost of the matrix construction is negligible here.
     auto flux_matrix = std::make_shared<CompressedDataStorage<double>>(
@@ -555,11 +535,6 @@ create_flux_vector_source_matrix(const std::vector<int>& row_indices,
     auto vector_source_matrix = std::make_shared<CompressedDataStorage<double>>(
         num_rows, SPATIAL_DIM * num_cols, row_ptr_vector_source, col_idx_vector_source,
         values_vector_source);
-
-    duration = std::chrono::high_resolution_clock::now() - tick;
-    std::cout << "end: " << duration.count() << " seconds."
-                << std::endl;
-    tick = std::chrono::high_resolution_clock::now();
 
     return {flux_matrix, vector_source_matrix};
 }

--- a/src/multipoint_common.cpp
+++ b/src/multipoint_common.cpp
@@ -21,7 +21,8 @@ BasisConstructor::BasisConstructor(const int dim)
     m_rhs_matrix = MatrixXd::Identity(dim + 1, dim + 1);
 }
 
-std::vector<std::array<double, 3>> BasisConstructor::compute_basis_functions(
+std::vector<std::array<double, 3>> BasisConstructor::
+compute_basis_functions(
     const std::vector<std::array<double, 3>>& coords)
 {
     double inv[4][4];  // To store the inverse matrix.
@@ -211,7 +212,9 @@ InteractionRegion::InteractionRegion(const int node, const int dim, const Grid& 
     : m_node(node), m_dim(dim), m_faces(), m_cells(), m_faces_of_cells(), m_main_cell_of_faces()
 {
     // Initialize the interaction region based on the node and the grid.
-    auto face_indices = grid.faces_of_node(node);
+    auto face_indices_span = grid.faces_of_node(node);
+    // Copying the face_indices data to a new vector to sort it.
+    std::vector<int> face_indices(face_indices_span.begin(), face_indices_span.end());
     // Sort the face indices to ensure consistent ordering.
     std::sort(face_indices.begin(), face_indices.end());
 
@@ -221,11 +224,8 @@ InteractionRegion::InteractionRegion(const int node, const int dim, const Grid& 
         m_faces[face_indices[i]] = static_cast<int>(i);
     }
 
-    m_cells = std::vector<int>();
     m_cells.reserve(face_indices.size());
     m_main_cell_of_faces = std::vector<int>(face_indices.size(), -1);
-
-    m_faces_of_cells = std::map<int, std::vector<int>>();
 
     // For the cell indexing, use an unordered set for fast lookup, store the cells
     // in a vector to maintain the order of insertion.
@@ -235,7 +235,7 @@ InteractionRegion::InteractionRegion(const int node, const int dim, const Grid& 
     {
         const int face = face_indices[i];
         // Get the cells associated with the face.
-        auto cells_of_face = grid.cells_of_face(face);
+        const auto cells_of_face = grid.cells_of_face(face);
         // Associate the first cell with the face for the flux computation. There will
         // always be at least one cell associated with the face.
         m_main_cell_of_faces[i] = cells_of_face[0];

--- a/src/profile_mpfa.cpp
+++ b/src/profile_mpfa.cpp
@@ -19,7 +19,7 @@ int main()
 
     // For 3D Cartesian grids.
     std::unique_ptr<Grid> grid_3d;
-    const std::vector<int> num_cells_3d = {300, 80, 30};
+    const std::vector<int> num_cells_3d = {30, 80, 30};
     // const std::vector<int> num_cells_3d = {480, 40, 30};
 
 

--- a/src/profile_mpfa.cpp
+++ b/src/profile_mpfa.cpp
@@ -19,7 +19,7 @@ int main()
 
     // For 3D Cartesian grids.
     std::unique_ptr<Grid> grid_3d;
-    const std::vector<int> num_cells_3d = {30, 20, 30};
+    const std::vector<int> num_cells_3d = {300, 40, 30};
 
     // Create grids, compute geometry.
     if (false)  // Replace with actual condition to choose between 2D and 3D
@@ -33,8 +33,27 @@ int main()
     grid->compute_geometry();
 
     std::vector<double> k_xx(grid->num_cells());
+    std::vector<double> k_yy(grid->num_cells());
+    std::vector<double> k_zz(grid->num_cells());
+    std::vector<double> k_xy(grid->num_cells());
+    std::vector<double> k_xz(grid->num_cells());
+    std::vector<double> k_yz(grid->num_cells());
     std::iota(k_xx.begin(), k_xx.end(), 1.0);  // Fill with 1.0, 2.0, ..., num_cells
-    SecondOrderTensor tensor = SecondOrderTensor(grid->dim(), grid->num_cells(), k_xx);
+    for (auto i{0}; i < grid->num_cells(); ++i)
+    {
+        k_yy[i] = k_xx[i] * 2;
+        k_zz[i] = k_xx[i] * 3;
+        k_xy[i] = k_xx[i] * -1;
+        k_xz[i] = k_xx[i] * -0.5;
+        k_yz[i] = k_xx[i] * -0.3;
+    }
+
+    SecondOrderTensor tensor = SecondOrderTensor(grid->dim(), grid->num_cells(), k_xx)
+                                   .with_kyy(k_yy)
+                                   .with_kzz(k_zz)
+                                   .with_kxy(k_xy)
+                                   .with_kxz(k_xz)
+                                   .with_kyz(k_yz);
 
     // Create a mock boundary condition map
     std::vector<int> boundary_faces = grid->boundary_faces();
@@ -55,9 +74,12 @@ int main()
 
     auto start = std::chrono::high_resolution_clock::now();
     // Call the mpfa function
+
+    int num_runs = 5;
+
     try
     {
-        for (int i = 0; i < 3; ++i)
+        for (int i = 0; i < num_runs; ++i)
         {
             ScalarDiscretization result = mpfa(*grid, tensor, bc_map);
             std::cout << "mpfa function executed successfully." << std::endl;
@@ -69,7 +91,8 @@ int main()
     }
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = end - start;
-    std::cout << "Elapsed time for 3 runs: " << elapsed.count() << " seconds." << std::endl;
+    std::cout << "Elapsed time for " << num_runs << " runs: " << elapsed.count() << " seconds."
+              << std::endl;
 
     return 0;
 }

--- a/src/profile_mpfa.cpp
+++ b/src/profile_mpfa.cpp
@@ -19,7 +19,9 @@ int main()
 
     // For 3D Cartesian grids.
     std::unique_ptr<Grid> grid_3d;
-    const std::vector<int> num_cells_3d = {300, 40, 30};
+    const std::vector<int> num_cells_3d = {300, 80, 30};
+    // const std::vector<int> num_cells_3d = {480, 40, 30};
+
 
     // Create grids, compute geometry.
     if (false)  // Replace with actual condition to choose between 2D and 3D
@@ -58,7 +60,7 @@ int main()
     // Create a mock boundary condition map
     std::vector<int> boundary_faces = grid->boundary_faces();
 
-    std::map<int, BoundaryCondition> bc_map;
+    std::unordered_map<int, BoundaryCondition> bc_map;
     for (int face_id : boundary_faces)
     {
         // For testing, assign Dirichlet to even faces and Neumann to odd faces

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -7,13 +7,7 @@
 SecondOrderTensor::SecondOrderTensor(const int dim, const int num_cells,
                                      const std::vector<double>& k_xx)
     : m_dim(dim),
-      m_num_cells(num_cells),
-      m_k_xx(k_xx),
-      m_k_yy(),
-      m_k_xy(),
-      m_k_zz(),
-      m_k_xz(),
-      m_k_yz()
+      m_num_cells(num_cells)
 {
     if (k_xx.size() != static_cast<size_t>(num_cells))
     {
@@ -22,8 +16,13 @@ SecondOrderTensor::SecondOrderTensor(const int dim, const int num_cells,
     m_is_isotropic = true;
     m_is_diagonal = true;
 
-    // Initialize a vector of zeros for the off-diagonal components.
-    m_zeros.resize(num_cells, 0.0);
+    m_k_full.resize(num_cells * DATA_PER_CELL, 0.0);
+    // Filling the diagonal components.
+    for (auto i{0}; i < num_cells; ++i) {
+        m_k_full[i * 6 + K_XX_OFFSET] = k_xx[i];
+        m_k_full[i * 6 + K_YY_OFFSET] = k_xx[i];
+        m_k_full[i * 6 + K_ZZ_OFFSET] = k_xx[i];
+    }
 }
 
 SecondOrderTensor::~SecondOrderTensor() = default;
@@ -46,7 +45,9 @@ SecondOrderTensor& SecondOrderTensor::with_kyy(const std::vector<double>& k_yy)
     {
         throw std::invalid_argument("Size of k_yy does not match num_cells.");
     }
-    m_k_yy = k_yy;
+    for (auto i{0}; i < m_num_cells; ++i) {
+        m_k_full[i * 6 + K_YY_OFFSET] = k_yy[i];
+    }
     m_is_isotropic = false;
     return *this;
 }
@@ -57,16 +58,9 @@ SecondOrderTensor& SecondOrderTensor::with_kxy(const std::vector<double>& k_xy)
     {
         throw std::invalid_argument("Size of k_xy does not match num_cells.");
     }
-    m_k_xy = k_xy;
-    m_is_diagonal = false;
 
-    if (m_k_yy.empty())
-    {
-        m_k_yy = m_k_xx;
-    }
-    if (m_k_zz.empty() && m_dim == 3)
-    {
-        m_k_zz = m_k_xx;
+    for (auto i{0}; i < m_num_cells; ++i) {
+        m_k_full[i * 6 + K_XY_OFFSET] = k_xy[i];
     }
     m_is_isotropic = false;
     m_is_diagonal = false;
@@ -84,7 +78,9 @@ SecondOrderTensor& SecondOrderTensor::with_kzz(const std::vector<double>& k_zz)
     {
         throw std::invalid_argument("Size of k_zz does not match num_cells.");
     }
-    m_k_zz = k_zz;
+    for (auto i{0}; i < m_num_cells; ++i) {
+        m_k_full[i * 6 + K_ZZ_OFFSET] = k_zz[i];
+    }
     m_is_isotropic = false;
     return *this;
 }
@@ -99,16 +95,8 @@ SecondOrderTensor& SecondOrderTensor::with_kxz(const std::vector<double>& k_xz)
     {
         throw std::invalid_argument("Size of k_xz does not match num_cells.");
     }
-    m_k_xz = k_xz;
-    m_is_diagonal = false;
-
-    if (m_k_yy.empty())
-    {
-        m_k_yy = m_k_xx;
-    }
-    if (m_k_zz.empty())
-    {
-        m_k_zz = m_k_xx;
+    for (auto i{0}; i < m_num_cells; ++i) {
+        m_k_full[i * 6 + K_XZ_OFFSET] = k_xz[i];
     }
     m_is_isotropic = false;
     m_is_diagonal = false;
@@ -126,19 +114,12 @@ SecondOrderTensor& SecondOrderTensor::with_kyz(const std::vector<double>& k_yz)
     {
         throw std::invalid_argument("Size of k_yz does not match num_cells.");
     }
-    m_k_yz = k_yz;
-    m_is_diagonal = false;
-
-    if (m_k_yy.empty())
-    {
-        m_k_yy = m_k_xx;
-    }
-    if (m_k_zz.empty())
-    {
-        m_k_zz = m_k_xx;
+    for (auto i{0}; i < m_num_cells; ++i) {
+        m_k_full[i * 6 + K_YZ_OFFSET] = k_yz[i];
     }
     m_is_isotropic = false;
     m_is_diagonal = false;
+
 
     return *this;
 }
@@ -147,32 +128,4 @@ SecondOrderTensor& SecondOrderTensor::with_kyz(const std::vector<double>& k_yz)
 const int SecondOrderTensor::dim() const
 {
     return m_dim;
-}
-
-double SecondOrderTensor::isotropic_data(int cell) const
-{
-    return m_k_xx[cell];
-}
-
-std::vector<double> SecondOrderTensor::diagonal_data(int cell) const
-{
-    // Always return a vector of size 3: [xx, yy, zz], zero-padded for 2D
-    std::vector<double> diag(3);
-    diag[0] = m_k_xx[cell];
-    diag[1] = m_k_yy.empty() ? m_k_xx[cell] : m_k_yy[cell];
-    diag[2] = m_k_zz.empty() ? m_k_xx[cell] : m_k_zz[cell];
-    return diag;
-}
-
-std::vector<double> SecondOrderTensor::full_data(int cell) const
-{
-    // Always return a vector of size 6: [xx, yy, zz, xy, xz, yz], zero-padded for 2D
-    std::vector<double> tensor(6);
-    tensor[0] = m_k_xx[cell];
-    tensor[1] = m_k_yy.empty() ? m_k_xx[cell] : m_k_yy[cell];
-    tensor[2] = m_k_zz.empty() ? m_k_xx[cell] : m_k_zz[cell];
-    tensor[3] = m_k_xy.empty() ? 0.0 : m_k_xy[cell];
-    tensor[4] = m_k_xz.empty() ? 0.0 : m_k_xz[cell];
-    tensor[5] = m_k_yz.empty() ? 0.0 : m_k_yz[cell];
-    return tensor;
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -120,7 +120,6 @@ SecondOrderTensor& SecondOrderTensor::with_kyz(const std::vector<double>& k_yz)
     m_is_isotropic = false;
     m_is_diagonal = false;
 
-
     return *this;
 }
 

--- a/src/tpfa.cpp
+++ b/src/tpfa.cpp
@@ -51,21 +51,14 @@ const double nKproj(const std::vector<double>& face_normal, const SecondOrderTen
         {
             for (int j{0}; j < dim; ++j)
             {
-                double tensor_val;
-                if (i == 0 && j == 0)
-                    tensor_val = full_data[0];
-                else if (i == 1 && j == 1)
-                    tensor_val = full_data[1];
-                else if (i == 2 && j == 2)
-                    tensor_val = full_data[2];
-                else if (i == 0 && j == 1 || i == 1 && j == 0)
-                    tensor_val = full_data[3];
-                else if (i == 0 && j == 2 || i == 2 && j == 0)
-                    tensor_val = full_data[4];
-                else if (i == 1 && j == 2 || i == 2 && j == 1)
-                    tensor_val = full_data[5];
-
-                prod += sign * face_normal[i] * cell_face_vec[j] * tensor_val;
+                if (i == j) {
+                    double tensor_val = full_data[i];  // 0,1,2 for diagonal
+                    prod += sign * face_normal[i] * cell_face_vec[j] * tensor_val;
+                } else {
+                    int k = 2 + i + j;
+                    double tensor_val = full_data[k];
+                    prod += sign * face_normal[i] * cell_face_vec[j] * tensor_val;
+                }
             }
         }
         return prod / dist;

--- a/src/tpfa.cpp
+++ b/src/tpfa.cpp
@@ -1,6 +1,6 @@
 #include <array>
 #include <iostream>
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 #include "../include/discr.h"
@@ -67,7 +67,7 @@ const double nKproj(const std::vector<double>& face_normal, const SecondOrderTen
 }  // namespace
 
 ScalarDiscretization tpfa(const Grid& grid, const SecondOrderTensor& tensor,
-                          const std::map<int, BoundaryCondition>& bc_map)
+                          const std::unordered_map<int, BoundaryCondition>& bc_map)
 {
     const int num_boundary_faces = bc_map.size();
     const int num_internal_faces = grid.num_faces() - num_boundary_faces;

--- a/src/tpfa.cpp
+++ b/src/tpfa.cpp
@@ -36,7 +36,7 @@ const double nKproj(const std::vector<double>& face_normal, const SecondOrderTen
     else if (tensor.is_diagonal())
     {
         double prod = 0.0;
-        std::vector<double> diag = tensor.diagonal_data(cell_ind);
+        auto diag = tensor.diagonal_data(cell_ind);
         for (int i{0}; i < dim; ++i)
         {
             prod += sign * face_normal[i] * cell_face_vec[i] * diag[i];
@@ -46,7 +46,7 @@ const double nKproj(const std::vector<double>& face_normal, const SecondOrderTen
     else
     {
         double prod = 0.0;
-        std::vector<double> full_data = tensor.full_data(cell_ind);
+        auto full_data = tensor.full_data(cell_ind);
         for (int i{0}; i < dim; ++i)
         {
             for (int j{0}; j < dim; ++j)
@@ -145,7 +145,7 @@ ScalarDiscretization tpfa(const Grid& grid, const SecondOrderTensor& tensor,
     for (int face_ind{0}; face_ind < grid.num_faces(); ++face_ind)
     {
         // Get various properties of the face and its first neighboring cell.
-        std::vector<int> cells = grid.cells_of_face(face_ind);
+        auto cells = grid.cells_of_face(face_ind);
         face_center = grid.face_center(face_ind);
         normal = grid.face_normal(face_ind);
         const int cell_a = cells[0];

--- a/src/tpfa.cpp
+++ b/src/tpfa.cpp
@@ -273,20 +273,20 @@ ScalarDiscretization tpfa(const Grid& grid, const SecondOrderTensor& tensor,
     // Create the ScalarDiscretization object and return it.
     ScalarDiscretization discr;
     discr.flux = std::make_shared<CompressedDataStorage<double>>(grid.num_faces(), grid.num_cells(),
-                                                                 row_ptr_flux, col_idx_flux, trm);
+                                                                 std::move(row_ptr_flux), std::move(col_idx_flux), std::move(trm));
     discr.bound_flux = std::make_shared<CompressedDataStorage<double>>(
-        grid.num_faces(), grid.num_faces(), row_ptr_bound_flux, col_idx_bound_flux, trm_bound);
+        grid.num_faces(), grid.num_faces(), std::move(row_ptr_bound_flux), std::move(col_idx_bound_flux), std::move(trm_bound));
     discr.vector_source = std::make_shared<CompressedDataStorage<double>>(
-        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source, col_idx_vector_source,
-        vector_source);
+        grid.num_faces(), grid.num_cells() * DIM, std::move(row_ptr_vector_source), std::move(col_idx_vector_source),
+        std::move(vector_source));
     discr.bound_pressure_vector_source = std::make_shared<CompressedDataStorage<double>>(
-        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source_bound,
-        col_idx_vector_source_bound, vector_source_bound);
+        grid.num_faces(), grid.num_cells() * DIM, std::move(row_ptr_vector_source_bound),
+        std::move(col_idx_vector_source_bound), std::move(vector_source_bound));
     discr.bound_pressure_cell = std::make_shared<CompressedDataStorage<double>>(
-        grid.num_faces(), grid.num_cells(), row_ptr_bound_pressure_cell,
-        col_idx_bound_pressure_cell, bound_pressure_cell);
+        grid.num_faces(), grid.num_cells(), std::move(row_ptr_bound_pressure_cell),
+        std::move(col_idx_bound_pressure_cell), std::move(bound_pressure_cell));
     discr.bound_pressure_face = std::make_shared<CompressedDataStorage<double>>(
-        grid.num_faces(), grid.num_faces(), row_ptr_bound_pressure_face,
-        col_idx_bound_pressure_face, bound_pressure_face);
+        grid.num_faces(), grid.num_faces(), std::move(row_ptr_bound_pressure_face),
+        std::move(col_idx_bound_pressure_face), std::move(bound_pressure_face));
     return discr;
 }

--- a/src/tpfa.cpp
+++ b/src/tpfa.cpp
@@ -277,38 +277,23 @@ ScalarDiscretization tpfa(const Grid& grid, const SecondOrderTensor& tensor,
         row_ptr_bound_pressure_face.push_back(col_idx_bound_pressure_face.size());
     }
 
-    // Gather the data into the compressed data storage.
-    CompressedDataStorage<double>* flux = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_cells(), row_ptr_flux, col_idx_flux, trm);
-
-    CompressedDataStorage<double>* bound_flux = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_faces(), row_ptr_bound_flux, col_idx_bound_flux, trm_bound);
-
-    CompressedDataStorage<double>* bound_pressure_cell_storage = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_cells(), row_ptr_bound_pressure_cell,
-        col_idx_bound_pressure_cell, bound_pressure_cell);
-
-    CompressedDataStorage<double>* bound_pressure_face_storage = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_faces(), row_ptr_bound_pressure_face,
-        col_idx_bound_pressure_face, bound_pressure_face);
-
-    CompressedDataStorage<double>* vector_source_storage = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source, col_idx_vector_source,
-        vector_source);
-    CompressedDataStorage<double>* vector_source_bound_storage = new CompressedDataStorage<double>(
-        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source_bound,
-        col_idx_vector_source_bound, vector_source_bound);
-
     // Create the ScalarDiscretization object and return it.
     ScalarDiscretization discr;
-    discr.flux = std::unique_ptr<CompressedDataStorage<double>>(flux);
-    discr.bound_flux = std::unique_ptr<CompressedDataStorage<double>>(bound_flux);
-    discr.vector_source = std::unique_ptr<CompressedDataStorage<double>>(vector_source_storage);
-    discr.bound_pressure_vector_source =
-        std::unique_ptr<CompressedDataStorage<double>>(vector_source_bound_storage);
-    discr.bound_pressure_cell =
-        std::unique_ptr<CompressedDataStorage<double>>(bound_pressure_cell_storage);
-    discr.bound_pressure_face =
-        std::unique_ptr<CompressedDataStorage<double>>(bound_pressure_face_storage);
+    discr.flux = std::make_shared<CompressedDataStorage<double>>(grid.num_faces(), grid.num_cells(),
+                                                                 row_ptr_flux, col_idx_flux, trm);
+    discr.bound_flux = std::make_shared<CompressedDataStorage<double>>(
+        grid.num_faces(), grid.num_faces(), row_ptr_bound_flux, col_idx_bound_flux, trm_bound);
+    discr.vector_source = std::make_shared<CompressedDataStorage<double>>(
+        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source, col_idx_vector_source,
+        vector_source);
+    discr.bound_pressure_vector_source = std::make_shared<CompressedDataStorage<double>>(
+        grid.num_faces(), grid.num_cells() * DIM, row_ptr_vector_source_bound,
+        col_idx_vector_source_bound, vector_source_bound);
+    discr.bound_pressure_cell = std::make_shared<CompressedDataStorage<double>>(
+        grid.num_faces(), grid.num_cells(), row_ptr_bound_pressure_cell,
+        col_idx_bound_pressure_cell, bound_pressure_cell);
+    discr.bound_pressure_face = std::make_shared<CompressedDataStorage<double>>(
+        grid.num_faces(), grid.num_faces(), row_ptr_bound_pressure_face,
+        col_idx_bound_pressure_face, bound_pressure_face);
     return discr;
 }

--- a/tests/cpp/test_compressed_storage.cpp
+++ b/tests/cpp/test_compressed_storage.cpp
@@ -36,7 +36,7 @@ TEST_F(CompressedDataStorageTest, ConstructorWithValues)
 // Test the cols_in_row method
 TEST_F(CompressedDataStorageTest, ColsInRow)
 {
-    std::vector<int> cols = storage->cols_in_row(1);
+    auto cols = storage->cols_in_row(1);
     EXPECT_EQ(cols[0], 1);
     EXPECT_EQ(cols[1], 2);
 }

--- a/tests/cpp/test_compressed_storage.cpp
+++ b/tests/cpp/test_compressed_storage.cpp
@@ -13,7 +13,8 @@ class CompressedDataStorageTest : public ::testing::Test
 
     void SetUp() override
     {
-        storage = new CompressedDataStorage<double>(3, 3, row_ptr, col_idx, values);
+        storage = new CompressedDataStorage<double>(3, 3, std::move(row_ptr), std::move(col_idx),
+                                                    std::move(values));
     }
 
     void TearDown() override

--- a/tests/cpp/test_grid.cpp
+++ b/tests/cpp/test_grid.cpp
@@ -98,7 +98,8 @@ TEST_F(GridTest, FacesOfNodeCartGrid2d)
     // expected values.
     for (auto const& [node, expected_faces] : expected_faces_of_node)
     {
-        std::vector<int> face_nodes = grid_2d->faces_of_node(node);
+        auto face_nodes_span = grid_2d->faces_of_node(node);
+        std::vector<int> face_nodes(face_nodes_span.begin(), face_nodes_span.end());
         std::sort(face_nodes.begin(), face_nodes.end());
         EXPECT_EQ(face_nodes.size(), expected_faces.size());
         for (size_t i = 0; i < expected_faces.size(); ++i)
@@ -146,7 +147,8 @@ TEST_F(GridTest, CellsOfFaceCartGrid2d)
     // expected values.
     for (auto const& [face, expected_cells] : expected_cells_of_face)
     {
-        std::vector<int> cells = grid_2d->cells_of_face(face);
+        auto cells_span = grid_2d->cells_of_face(face);
+        std::vector<int> cells(cells_span.begin(), cells_span.end());
         std::sort(cells.begin(), cells.end());
         EXPECT_EQ(cells.size(), expected_cells.size());
         for (size_t i = 0; i < expected_cells.size(); ++i)
@@ -284,7 +286,8 @@ TEST_F(GridTest, FacesOfNodeCartGrid3d)
     // Loop over the keys of the map and compare with the expected values.
     for (auto const& [node, expected_faces] : expected_faces_of_node)
     {
-        std::vector<int> face_nodes = grid_3d->faces_of_node(node);
+        auto face_nodes_span = grid_3d->faces_of_node(node);
+        std::vector<int> face_nodes(face_nodes_span.begin(), face_nodes_span.end());
         std::sort(face_nodes.begin(), face_nodes.end());
         EXPECT_EQ(face_nodes.size(), expected_faces.size());
         for (size_t i = 0; i < expected_faces.size(); ++i)
@@ -315,7 +318,8 @@ TEST_F(GridTest, CellsOfFaceCartGrid3d)
     // Loop over the keys of the map and compare with the expected values.
     for (auto const& [face, expected_cells] : expected_cells_of_face)
     {
-        std::vector<int> cells = grid_3d->cells_of_face(face);
+        auto cells_span = grid_3d->cells_of_face(face);
+        std::vector<int> cells(cells_span.begin(), cells_span.end());
         std::sort(cells.begin(), cells.end());
         EXPECT_EQ(cells.size(), expected_cells.size());
         for (size_t i = 0; i < expected_cells.size(); ++i)

--- a/tests/cpp/test_mpfa.cpp
+++ b/tests/cpp/test_mpfa.cpp
@@ -12,7 +12,7 @@ class MPFA : public ::testing::Test
    protected:
     std::unique_ptr<Grid> grid_2d;
     ScalarDiscretization discr_2d;
-    std::map<int, BoundaryCondition> bc_map_2d;
+    std::unordered_map<int, BoundaryCondition> bc_map_2d;
 
     // Constructor. Create a dummy tensor and empty discretization.
     MPFA() : grid_2d(nullptr), discr_2d(), bc_map_2d() {}

--- a/tests/cpp/test_tpfa.cpp
+++ b/tests/cpp/test_tpfa.cpp
@@ -11,7 +11,7 @@ class TPFA : public ::testing::Test
     std::unique_ptr<Grid> grid;
     SecondOrderTensor tensor;
     ScalarDiscretization discr;
-    std::map<int, BoundaryCondition> bc_map;
+    std::unordered_map<int, BoundaryCondition> bc_map;
 
     // Constructor. Create a dummy tensor and empty discretization.
     TPFA() : grid(nullptr), tensor(2, 1, {1.0}), discr(), bc_map() {}


### PR DESCRIPTION
This addresses #5 and #6. Key changes:
- second order tensor changed the underlying storage to AoS
- applied move semantics to creation of csr matrices and some other places
- avoided extra copying where possible
- improved cache locality

On my machine, the -O3  build run time for `profile_mpfa.cpp` with `(30, 80, 30)` grid improves from `16.5` to `11.2` seconds.

Authored by @mikeljordan and me. 
